### PR TITLE
INFRA-303: Add directory-build-props-path input to action.yml and upd…

### DIFF
--- a/dotnet-component-release/README.md
+++ b/dotnet-component-release/README.md
@@ -9,6 +9,7 @@ It is tailored to fit smoothly into your CI/CD pipeline and supports all standar
 | -------------- | ------------------------------------------------- | -------- | ------- |
 | `version`      | Version to publish. Used only when type is manual | No       | –       |
 | `github-token` | GitHub token for authentication                   | Yes      | –       |
+| `directory-build-props-path` | Path to `Directory.Build.props` file | No | `Directory.Build.props` |
 
 ## 📝 Example Usage
 
@@ -23,4 +24,5 @@ jobs:
               type: 'manual'
               version: '1.0.0-amazing-feature.1'
               github-token: ${{ secrets.PAT_TOKEN }}
+              directory-build-props-path: src/AcquisitionConnectorShl/Directory.Build.props
 ```

--- a/dotnet-component-release/action.yml
+++ b/dotnet-component-release/action.yml
@@ -9,6 +9,10 @@ inputs:
     required: false
     description: "The version number (manual)"
     default: ""
+  directory-build-props-path:
+    required: false
+    description: "Path to Directory.Build.props"
+    default: "Directory.Build.props"
 
 runs:
   using: composite
@@ -30,12 +34,12 @@ runs:
       shell: bash
       run: |
         version="${{ inputs.version }}"
-        [[ -n "${{ inputs.version }}" ]] || version=$(python3 "${{ github.action_path }}/../scripts/nuget/generate-version.py" release)
+        [[ -n "${{ inputs.version }}" ]] || version=$(python3 "${{ github.action_path }}/../scripts/nuget/generate-version.py" release --props-file "${{ inputs.directory-build-props-path }}")
         echo "version=$version" >> $GITHUB_OUTPUT
 
     - name: Update package version
       shell: bash
-      run: python3 "${{ github.action_path }}/../scripts/nuget/update-version.py" --new-version ${{ steps.determine_version.outputs.version }}
+      run: python3 "${{ github.action_path }}/../scripts/nuget/update-version.py" --new-version ${{ steps.determine_version.outputs.version }} --props-file "${{ inputs.directory-build-props-path }}"
 
 
     - name: Commit Changes

--- a/scripts/nuget/generate-version.py
+++ b/scripts/nuget/generate-version.py
@@ -3,14 +3,18 @@ import xml.etree.ElementTree as ET
 import sys
 
 
-def extract_version_from_solution():
+def is_version_tag(tag):
+    return tag.split("}")[-1] == "Version"
+
+
+def extract_version_from_solution(props_file):
     """Extract the current version from Directory.Build.props"""
     try:
-        tree = ET.parse('Directory.Build.props')
+        tree = ET.parse(props_file)
         root = tree.getroot()
 
         for element in root.iter():
-            if element.tag in "Version":
+            if is_version_tag(element.tag):
                 return element.text.strip()
 
         print("The <Version> tag was not found in the Directory.Build.props file.")
@@ -85,14 +89,20 @@ def main():
 
     alpha_parser = subparsers.add_parser("alpha", help="Generate alpha version")
     alpha_parser.add_argument("--branch", required=True, help="Name of the branch")
+    alpha_parser.add_argument("--props-file", default="Directory.Build.props", help="Path to Directory.Build.props")
 
     rc_parser = subparsers.add_parser("rc", help="Generate release candidate version")
+    rc_parser.add_argument("--props-file", default="Directory.Build.props", help="Path to Directory.Build.props")
 
     release_parser = subparsers.add_parser("release", help="Generate release version")
+    release_parser.add_argument("--props-file", default="Directory.Build.props", help="Path to Directory.Build.props")
+
+    get_parser.add_argument("--props-file", default="Directory.Build.props", help="Path to Directory.Build.props")
 
     args = parser.parse_args()
 
-    current_version = extract_version_from_solution()
+    props_file = getattr(args, "props_file", "Directory.Build.props")
+    current_version = extract_version_from_solution(props_file)
     if not current_version:
         print("Invalid format", file=sys.stderr)
         sys.exit(1)

--- a/scripts/nuget/update-version.py
+++ b/scripts/nuget/update-version.py
@@ -2,17 +2,21 @@ import argparse
 import xml.etree.ElementTree as ET
 
 
-def write_version_to_csproj(new_version):
+def is_version_tag(tag):
+    return tag.split("}")[-1] == "Version"
+
+
+def write_version_to_csproj(new_version, props_file):
     try:
-        tree = ET.parse('Directory.Build.props')
+        tree = ET.parse(props_file)
         root = tree.getroot()
 
         for element in root.iter():
-            if element.tag in "Version":
+            if is_version_tag(element.tag):
                 element.text = new_version
                 break
 
-        tree.write('Directory.Build.props')
+        tree.write(props_file)
         print("Version updated successfully.")
     except Exception as e:
         print(f"An error occurred while writing the version to the .csproj file: {e}")
@@ -21,11 +25,13 @@ def write_version_to_csproj(new_version):
 def main():
     parser = argparse.ArgumentParser(description="Write version number to .csproj file.")
     parser.add_argument("--new-version", required=True, help="New version number to write to .csproj file")
+    parser.add_argument("--props-file", default="Directory.Build.props", help="Path to Directory.Build.props")
     args = parser.parse_args()
 
     new_version = args.new_version
+    props_file = args.props_file
 
-    write_version_to_csproj(new_version)
+    write_version_to_csproj(new_version, props_file)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request adds support for specifying a custom path to the `Directory.Build.props` file in the .NET component release workflow. This enhancement allows the workflow and associated scripts to work with projects where the props file is not in the default location, increasing flexibility and usability.

**Workflow and script improvements:**

* Added a new `directory-build-props-path` input to the GitHub Action (`action.yml`) and documented it in the `README.md`, allowing users to specify the path to their `Directory.Build.props` file. [[1]](diffhunk://#diff-0139a647a30f97a0a4c18ed23cce97927bef4db96a0bf3e027f883cc6ecd92aeR12-R15) [[2]](diffhunk://#diff-0bc69c558c62e4e3a5c757a0bda2975675cf500441dffdb9254a9fa07b2afd15R12) [[3]](diffhunk://#diff-0bc69c558c62e4e3a5c757a0bda2975675cf500441dffdb9254a9fa07b2afd15R27)
* Updated workflow steps to pass the custom props file path to the version generation and update scripts.

**Script enhancements:**

* Modified `generate-version.py` and `update-version.py` to accept a `--props-file` argument, defaulting to `Directory.Build.props`, and updated their logic to use the provided path when reading or updating the version. [[1]](diffhunk://#diff-b097cb9e982ab944503b85a39c49520388d6f0d994e9cea87fcf0f609f6ec748L6-R17) [[2]](diffhunk://#diff-b097cb9e982ab944503b85a39c49520388d6f0d994e9cea87fcf0f609f6ec748R92-R105) [[3]](diffhunk://#diff-1599c491e8530ea2fc0201cd66823dfa89aa316eae5a325210281b16fb9c161aL5-R19) [[4]](diffhunk://#diff-1599c491e8530ea2fc0201cd66823dfa89aa316eae5a325210281b16fb9c161aR28-R34)
* Improved XML tag handling in both scripts to correctly identify the `<Version>` element, even when XML namespaces are present. [[1]](diffhunk://#diff-b097cb9e982ab944503b85a39c49520388d6f0d994e9cea87fcf0f609f6ec748L6-R17) [[2]](diffhunk://#diff-1599c491e8530ea2fc0201cd66823dfa89aa316eae5a325210281b16fb9c161aL5-R19)