### PR TITLE
Enhance Terraform destroy action with additional inputs and apply opt…

### DIFF
--- a/terraform-destroy/README.md
+++ b/terraform-destroy/README.md
@@ -11,21 +11,29 @@ This composite GitHub Action creates a Terraform destroy plan for your Azure inf
 
 ## 📝 Optional Inputs
 
-| Input              | Description                                                                                   | Default     |
-|--------------------|-----------------------------------------------------------------------------------------------|-------------|
-| `directory`        | Path to the Terraform working directory                                                       | `terraform` |
-| `needs-approval`   | Whether to require manual approval before applying the destroy plan (recommended)             | `'true'`    |
-| `tfvars-content`   | Literal content for `terraform.tfvars` (single string, e.g., from secrets or workflow input)  | `''`        |
+| Input                | Description                                                                                   | Default      |
+|----------------------|-----------------------------------------------------------------------------------------------|--------------|
+| `azure-subscription` | Azure subscription to destroy in (defaults to `subscriptionId` in `azure-credentials`)       | `''`         |
+| `directory`          | Path to the Terraform working directory                                                       | `terraform`  |
+| `apply`              | Whether to run `terraform apply` on the generated destroy plan (`'true'` or `'false'`)       | `'false'`    |
+| `needs-approval`     | Manual approval gate before apply when `apply: 'true'`                                        | `'true'`     |
+| `tfvars-content`     | Literal content for `terraform.tfvars` (single string, e.g., from secrets or workflow input) | `''`         |
+| `plan-args`          | Additional arguments passed to `terraform plan` (e.g., `-refresh=true -replace=...`)         | `''`         |
 
 ## 📦 What it does
 
 - Exports `ARM_` environment variables from `azure-credentials` (clientId, clientSecret, subscriptionId, tenantId).
+- If `azure-subscription` is provided, it overrides `subscriptionId` from `azure-credentials`.
 - Installs Terraform 1.13.3.
 - Configures Git to use `github-token` for private module sources.
 - Optionally writes `tfvars-content` to `terraform.tfvars` in the working directory.
 - Runs `terraform init -upgrade`, `terraform validate`.
 - Creates a destroy plan using `terraform plan -destroy` and uploads artifacts: `tfdestroy.tfplan`, `tfdestroy.json`, and `result.txt`.
-- If `needs-approval: 'true'`, pauses for manual approval and then applies the destroy plan with `terraform apply tfdestroy.tfplan`.
+- Supports passing additional flags via `plan-args`.
+- Apply behavior:
+- If `apply: 'false'` (default), no apply is executed (plan only).
+- If `apply: 'true'` and `needs-approval: 'true'`, manual approval is required before apply.
+- If `apply: 'true'` and `needs-approval: 'false'`, apply runs immediately.
 
 ### azure-credentials
 ```
@@ -39,18 +47,7 @@ This composite GitHub Action creates a Terraform destroy plan for your Azure inf
 
 ## 🚀 Usage Examples
 
-### Plan destroy with approval before applying
-```
-  - name: Terraform destroy (with approval)
-    uses: your-org/terraform-destroy@v1
-    with:
-      azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
-      github-token: ${{ secrets.PAT_TOKEN }}
-      directory: 'infra/terraform'
-      needs-approval: 'true'
-```
-
-### Plan destroy only (no apply)
+### Plan only (no apply)
 ```
   - name: Terraform destroy plan only
     uses: your-org/terraform-destroy@v1
@@ -58,7 +55,30 @@ This composite GitHub Action creates a Terraform destroy plan for your Azure inf
       azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
       github-token: ${{ secrets.PAT_TOKEN }}
       directory: 'infra/terraform'
-      needs-approval: 'false'
+      apply: 'false'
+      plan-args: "-refresh=true"
 ```
 
-> Note: When `needs-approval` is set to `'false'`, the action will not apply the plan; it only produces and uploads the destroy artifacts for review.
+### Apply with manual approval (recommended)
+```
+  - name: Terraform destroy apply (with approval)
+    uses: your-org/terraform-destroy@v1
+    with:
+      azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+      github-token: ${{ secrets.PAT_TOKEN }}
+      directory: 'infra/terraform'
+      apply: 'true'
+      needs-approval: 'true'
+```
+
+### Apply immediately without approval (use with caution)
+```
+  - name: Terraform destroy apply (no approval)
+    uses: your-org/terraform-destroy@v1
+    with:
+      azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+      github-token: ${{ secrets.PAT_TOKEN }}
+      directory: 'infra/terraform'
+      apply: 'true'
+      needs-approval: 'false'
+```

--- a/terraform-destroy/action.yml
+++ b/terraform-destroy/action.yml
@@ -5,10 +5,17 @@ inputs:
   azure-credentials:
     required: true
     description: "Azure credentials for authentication"
+  azure-subscription:
+    required: false
+    description: "Azure subscription to destroy in (defaults to subscription in credentials)"
   directory:
     required: false
     default: 'terraform'
     description: Terraform working directory
+  apply:
+    required: false
+    default: 'false'
+    description: "Whether to run terraform apply on the destroy plan"
   needs-approval:
     required: false
     default: 'true'
@@ -16,6 +23,10 @@ inputs:
   tfvars-content:
     required: false
     description: "Content of the terraform.tfvars file (as a single string, from secrets or workflow input)"
+  plan-args:
+    required: false
+    default: ''
+    description: "Additional arguments to pass to terraform plan (e.g., '-refresh=true -replace=xxx')"
   github-token:
     required: true
     description: "GitHub token for private module access"
@@ -25,11 +36,14 @@ runs:
   steps:
     - name: Extract Azure credentials
       shell: bash
-      id: creds
       run: |
         echo "ARM_CLIENT_ID=$(echo '${{ inputs.azure-credentials }}' | jq -r .clientId)" >> $GITHUB_ENV
         echo "ARM_CLIENT_SECRET=$(echo '${{ inputs.azure-credentials }}' | jq -r .clientSecret)" >> $GITHUB_ENV
-        echo "ARM_SUBSCRIPTION_ID=$(echo '${{ inputs.azure-credentials }}' | jq -r .subscriptionId)" >> $GITHUB_ENV
+        if [ -n "${{ inputs.azure-subscription }}" ]; then
+          echo "ARM_SUBSCRIPTION_ID=${{ inputs.azure-subscription }}" >> $GITHUB_ENV
+        else
+          echo "ARM_SUBSCRIPTION_ID=$(echo '${{ inputs.azure-credentials }}' | jq -r .subscriptionId)" >> $GITHUB_ENV
+        fi
         echo "ARM_TENANT_ID=$(echo '${{ inputs.azure-credentials }}' | jq -r .tenantId)" >> $GITHUB_ENV
 
     - name: Setup Terraform
@@ -46,12 +60,14 @@ runs:
       if: ${{ inputs.tfvars-content && inputs.tfvars-content != '' }}
       shell: bash
       working-directory: ${{ inputs.directory }}
+      env:
+        TFVARS_CONTENT: ${{ inputs.tfvars-content }}
       run: |
         echo "📝 Creating terraform.tfvars from input"
-        cat <<EOF > terraform.tfvars
-        ${{ inputs.tfvars-content }}
-        EOF
-        echo "::add-mask::${{ inputs.tfvars-content }}"
+        while IFS= read -r line; do
+          echo "::add-mask::$line"
+        done <<< "$TFVARS_CONTENT"
+        printf '%s\n' "$TFVARS_CONTENT" > terraform.tfvars
         echo "✅ terraform.tfvars created successfully"
 
     - name: Terraform Init
@@ -68,22 +84,23 @@ runs:
       shell: bash
       working-directory: ${{ inputs.directory }}
       run: |
+        PLAN_ARGS="${{ inputs.plan-args }}"
+
         if [ -f "terraform.tfvars" ]; then
           echo "✅ terraform.tfvars found, using it."
-          terraform plan \
-            -destroy \
-            -input=false \
-            -no-color \
-            -var-file="terraform.tfvars" \
-            -out=tfdestroy.tfplan > result.txt 2>&1
+          CMD=(terraform plan -destroy -input=false -no-color -var-file="terraform.tfvars")
         else
           echo "⚠️ No terraform.tfvars found, running destroy plan without it."
-          terraform plan \
-            -destroy \
-            -input=false \
-            -no-color \
-            -out=tfdestroy.tfplan > result.txt 2>&1
+          CMD=(terraform plan -destroy -input=false -no-color)
         fi
+
+        if [ -n "$PLAN_ARGS" ]; then
+          echo "ℹ️ Adding custom plan arguments: $PLAN_ARGS"
+          CMD+=($PLAN_ARGS)
+        fi
+
+        CMD+=(-out=tfdestroy.tfplan)
+        "${CMD[@]}" > result.txt 2>&1
 
     - name: Terraform Show Destroy Plan
       if: always()
@@ -103,17 +120,23 @@ runs:
         retention-days: 15
 
     - name: Manual Approval
-      if: ${{ inputs.needs-approval == 'true' }}
+      if: ${{ inputs.apply == 'true' && inputs.needs-approval == 'true' }}
       uses: trstringer/manual-approval@v1.9.0
       with:
-        secret: ${{ secrets.PAT_TOKEN }}
+        secret: ${{ inputs.github-token }}
         approvers: 'Developers'
         minimum-approvals: 1
         issue-title: 'Approve Terraform Destroy'
         issue-body: 'Please review and approve the Terraform destroy operation.'
 
-    - name: Terraform Apply Destroy (after approval)
-      if: ${{ inputs.needs-approval == 'true' }}
+    - name: Terraform Apply Destroy (with approval)
+      if: ${{ inputs.apply == 'true' && inputs.needs-approval == 'true' }}
+      shell: bash
+      working-directory: ${{ inputs.directory }}
+      run: terraform apply -input=false -auto-approve tfdestroy.tfplan
+
+    - name: Terraform Apply Destroy (without approval)
+      if: ${{ inputs.apply == 'true' && inputs.needs-approval != 'true' }}
       shell: bash
       working-directory: ${{ inputs.directory }}
       run: terraform apply -input=false -auto-approve tfdestroy.tfplan


### PR DESCRIPTION
…ions

- Add `azure-subscription` input to specify the Azure subscription for destruction.
- Introduce `apply` input to control whether to run `terraform apply` on the destroy plan.
- Add `plan-args` input for passing additional arguments to `terraform plan`.
- Update README to reflect new inputs and usage examples.