### PR TITLE
Enhance Terraform destroy action with additional inputs and apply opt…

### DIFF
--- a/terraform-destroy/action.yml
+++ b/terraform-destroy/action.yml
@@ -121,7 +121,7 @@ runs:
 
     - name: Manual Approval
       if: ${{ inputs.apply == 'true' && inputs.needs-approval == 'true' }}
-      uses: trstringer/manual-approval@v1.9.0
+      uses: trstringer/manual-approval@v1.12.0
       with:
         secret: ${{ inputs.github-token }}
         approvers: 'Developers'


### PR DESCRIPTION
…ions

- Add `azure-subscription` input to specify the Azure subscription for destruction.
- Introduce `apply` input to control whether to run `terraform apply` on the destroy plan.
- Add `plan-args` input for passing additional arguments to `terraform plan`.
- Update README to reflect new inputs and usage examples.