### PR TITLE
Enhance Git configuration for private module access and logging

### DIFF
--- a/terraform-deploy/README.md
+++ b/terraform-deploy/README.md
@@ -25,7 +25,7 @@ This GitHub Action initializes, validates, plans, and optionally applies Terrafo
 - Exports ARM_ environment variables from `azure-credentials` (clientId, clientSecret, subscriptionId, tenantId).
 - If `azure-subscription` is provided, it overrides the `subscriptionId` from `azure-credentials`.
 - Installs Terraform 1.13.3.
-- Configures Git to use `github-token` for private module sources.
+- Configures Git to use `github-token` for private GitHub module sources using either `git::https://github.com/...` or `git::ssh://git@github.com/...` / `git@github.com:...` style URLs. The token must have read access to every private module repository referenced by the Terraform configuration.
 - Optionally writes `tfvars-content` to `terraform.tfvars` in the working directory.
 - Runs `terraform init -upgrade`, `terraform validate`, and `terraform plan`.
 - Supports passing additional plan flags through `plan-args` (e.g., `-refresh=true` or `-replace=...`).

--- a/terraform-deploy/action.yml
+++ b/terraform-deploy/action.yml
@@ -56,16 +56,23 @@ runs:
     - name: Configure Git credential URL
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        PRIVATE_MODULES_GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        if [ -z "$GITHUB_TOKEN" ]; then
+        if [ -z "$PRIVATE_MODULES_GITHUB_TOKEN" ]; then
           echo "github-token input is required for private Terraform module access."
           exit 1
         fi
 
-        echo "::add-mask::$GITHUB_TOKEN"
-        git config --global --add url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-        git config --global --add url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "git@github.com:"
+        echo "::add-mask::$PRIVATE_MODULES_GITHUB_TOKEN"
+        {
+          echo "PRIVATE_MODULES_GITHUB_TOKEN=$PRIVATE_MODULES_GITHUB_TOKEN"
+          echo "GIT_TERMINAL_PROMPT=0"
+        } >> "$GITHUB_ENV"
+
+        git config --global credential.https://github.com.username x-access-token
+        git config --global credential.https://github.com.helper '!f() { test "$1" = get && echo username=x-access-token && echo "password=$PRIVATE_MODULES_GITHUB_TOKEN"; }; f'
+        git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"
+        git config --global --add url."https://github.com/".insteadOf "git@github.com:"
 
     - name: Create terraform.tfvars from input
       if: ${{ inputs.tfvars-content && inputs.tfvars-content != '' }}

--- a/terraform-deploy/action.yml
+++ b/terraform-deploy/action.yml
@@ -55,8 +55,17 @@ runs:
 
     - name: Configure Git credential URL
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        git config --global url."https://${{ inputs.github-token }}@github.com/".insteadOf "https://github.com/"
+        if [ -z "$GITHUB_TOKEN" ]; then
+          echo "github-token input is required for private Terraform module access."
+          exit 1
+        fi
+
+        echo "::add-mask::$GITHUB_TOKEN"
+        git config --global --add url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+        git config --global --add url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "git@github.com:"
 
     - name: Create terraform.tfvars from input
       if: ${{ inputs.tfvars-content && inputs.tfvars-content != '' }}


### PR DESCRIPTION
This pull request improves how the GitHub Action handles authentication for private Terraform module sources on GitHub. The main changes ensure that the provided `github-token` is used for both HTTPS and SSH-style Git URLs, and that the token is required for accessing any private modules.

**Improvements to private module authentication:**

* Updated the documentation in `terraform-deploy/README.md` to clarify that the action now configures Git to use the `github-token` for both HTTPS and SSH-based GitHub URLs when accessing private module sources. It also notes that the token must have read access to all referenced private repositories.
* Enhanced the `terraform-deploy/action.yml` workflow to:
  * Require the `github-token` input and fail early if not provided.
  * Mask the token in logs for security.
  * Set up Git credential helpers so the token is used for both HTTPS and SSH-style GitHub URLs, ensuring seamless access to private modules regardless of the URL style.